### PR TITLE
feat(advanced): PER-8195 Phase 3 pilot — advanced example for Percy on Automate (selenium-js)

### DIFF
--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -1,0 +1,48 @@
+name: Advanced — Percy on Automate
+
+# PER-8195 Phase 3 — advanced example for @percy/selenium-webdriver (Automate mode).
+# Triggers manually only (`workflow_dispatch`). Percy on Automate CI requires a
+# real BrowserStack Automate session.
+on:
+  workflow_dispatch:
+    inputs:
+      driver:
+        description: 'Which driver to run'
+        required: true
+        default: 'selenium-webdriver'
+        type: choice
+        options:
+          - selenium-webdriver
+          - webdriverio
+
+jobs:
+  advanced:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: ${{ inputs.driver }}/advanced
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Sanity-check BrowserStack secrets
+        env:
+          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+        run: |
+          if [ -z "$BROWSERSTACK_USERNAME" ] || [ -z "$BROWSERSTACK_ACCESS_KEY" ]; then
+            echo "::error::BROWSERSTACK_USERNAME / BROWSERSTACK_ACCESS_KEY repo secrets are required for the advanced Percy on Automate job."
+            exit 1
+          fi
+      - name: Install advanced/ dependencies
+        run: npm install
+      - name: Run advanced tests against BrowserStack Automate
+        env:
+          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+          PERCY_BRANCH: ${{ github.ref_name }}
+          PERCY_COMMIT: ${{ github.sha }}
+        run: npx --no-install percy exec -- npm run test:advanced

--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -15,6 +15,9 @@ on:
           - selenium-webdriver
           - webdriverio
 
+permissions:
+  contents: read
+
 jobs:
   advanced:
     runs-on: ubuntu-latest

--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -23,17 +23,29 @@ jobs:
       run:
         working-directory: ${{ inputs.driver }}/advanced
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
-      - name: Sanity-check BrowserStack secrets
+          node-version: 22
+      - name: Verify driver directory exists
+        working-directory: .
+        run: |
+          if [ ! -d "${{ inputs.driver }}/advanced" ]; then
+            echo "::error::${{ inputs.driver }}/advanced does not exist yet — only 'selenium-webdriver' is implemented in this phase."
+            exit 1
+          fi
+      - name: Sanity-check required secrets
         env:
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
         run: |
-          if [ -z "$BROWSERSTACK_USERNAME" ] || [ -z "$BROWSERSTACK_ACCESS_KEY" ]; then
-            echo "::error::BROWSERSTACK_USERNAME / BROWSERSTACK_ACCESS_KEY repo secrets are required for the advanced Percy on Automate job."
+          missing=()
+          [ -z "$BROWSERSTACK_USERNAME" ] && missing+=(BROWSERSTACK_USERNAME)
+          [ -z "$BROWSERSTACK_ACCESS_KEY" ] && missing+=(BROWSERSTACK_ACCESS_KEY)
+          [ -z "$PERCY_TOKEN" ]            && missing+=(PERCY_TOKEN)
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing required repo secrets: ${missing[*]}"
             exit 1
           fi
       - name: Install advanced/ dependencies

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Example app used by the Percy JS Selenium tutorial and Percy JS WebdriverIO tutorial demonstrating Percy on Auomate JS Selenium and WebdriverIO integrations.
 
-> **New:** This repo ships an [`advanced/`](./selenium-webdriver/advanced) example covering the full applicable Percy on Automate feature surface for the `selenium-webdriver` driver. See the [Percy SDK Feature Matrix](https://docs.percy.io/docs/sdk-feature-matrix) for cross-SDK coverage. A `webdriverio/advanced/` symmetric example is planned.
+> **New:** This repo ships an [`advanced/`](./selenium-webdriver/advanced) example covering the full applicable Percy on Automate feature surface for the `selenium-webdriver` driver. See [`selenium-webdriver/advanced/matrix.yml`](./selenium-webdriver/advanced/matrix.yml) for the per-feature coverage matrix. A `webdriverio/advanced/` symmetric example is planned.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 Example app used by the Percy JS Selenium tutorial and Percy JS WebdriverIO tutorial demonstrating Percy on Auomate JS Selenium and WebdriverIO integrations.
 
+> **New:** This repo ships an [`advanced/`](./selenium-webdriver/advanced) example covering the full applicable Percy on Automate feature surface for the `selenium-webdriver` driver. See the [Percy SDK Feature Matrix](https://docs.percy.io/docs/sdk-feature-matrix) for cross-SDK coverage. A `webdriverio/advanced/` symmetric example is planned.
+
+## Examples
+
+| Driver | Example | What it shows | Run command |
+|---|---|---|---|
+| selenium-webdriver | `selenium-webdriver/tests/test.js` (basic) | Minimum viable: `percyScreenshot(driver, name)` calls. Start here. | `cd selenium-webdriver && npm test` |
+| selenium-webdriver | [`selenium-webdriver/advanced/`](./selenium-webdriver/advanced) | Full applicable Percy on Automate feature surface: ignore/consider regions (xpath, CSS selector, custom bbox), freeze_animation, percy_css, sync mode, test_case + labels. jest + Percy on Automate. See [`selenium-webdriver/advanced/README.md`](./selenium-webdriver/advanced/README.md). | `cd selenium-webdriver/advanced && npm install && npx percy exec -- npm run test:advanced` |
+| webdriverio | `webdriverio/test/specs/test.js` (basic) | Minimum viable: `percyScreenshot(browser, name)` calls. Start here. | `cd webdriverio && npm run base` |
+| webdriverio | `webdriverio/advanced/` (planned) | Planned — same matrix-row coverage via wdio + mocha. | — |
+
 
 # JS Selenium/WebdriverIO Tutorial
 The tutorial assumes you're already familiar with JavaScript and the selenium-webdriver/webdriverio framework. You'll still be able to follow along if you're not familiar with Selenium concepts, but we won't spend time introducing JS Selenium concepts. Also we will be using basic test frameworks to write tests.

--- a/selenium-webdriver/advanced/.gitignore
+++ b/selenium-webdriver/advanced/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+advanced-requests.json
+*.log

--- a/selenium-webdriver/advanced/.percy.yml
+++ b/selenium-webdriver/advanced/.percy.yml
@@ -1,0 +1,7 @@
+# PER-8195 — global config for Percy on Automate (selenium-webdriver
+# driver). Per-screenshot options in tests/advanced.test.js override these.
+
+version: 2
+
+percy:
+  defer_uploads: false

--- a/selenium-webdriver/advanced/README.md
+++ b/selenium-webdriver/advanced/README.md
@@ -1,0 +1,30 @@
+# Advanced Percy on Automate + Selenium-JS (selenium-webdriver driver)
+
+This directory exercises the full applicable Percy on Automate feature surface for `@percy/selenium-webdriver` (Automate mode, `percyScreenshot(driver, name, options)` posting to `/percy/automateScreenshot`). See the basic example at `selenium-webdriver/tests/test.js` for the minimum integration.
+
+## What this example covers
+
+A jest spec (`tests/advanced.test.js`) where each test exercises one row of the [Percy on Automate matrix](../../../../docs/advanced-example-feature-matrix.md): ignore regions via xpath/CSS selector/custom bbox, consider regions via xpath/CSS selector, freeze_animation, percy_css, sync mode, test_case + labels.
+
+Web-DOM-only options (widths, min_height, enable_javascript, scope, discovery, dom_transformation, responsiveSnapshotCapture, readiness preset, devicePixelRatio, browsers) marked `N/A` — Percy on Automate captures server-side from a live browser session, not by serializing the DOM.
+
+## Run locally
+
+Requires BrowserStack Automate hub credentials and a Percy project (Automate type):
+
+```bash
+cd selenium-webdriver/advanced
+npm install
+export BROWSERSTACK_USERNAME="<your username>"
+export BROWSERSTACK_ACCESS_KEY="<your access key>"
+export PERCY_TOKEN="<your project token>"      # do NOT commit this
+npx percy exec -- npm run test:advanced
+```
+
+## CI note
+
+The advanced CI job is `workflow_dispatch`-only — Percy on Automate CI requires a real BrowserStack Automate session.
+
+## Coverage matrix
+
+States: `Covered` / `N/A — <reason>` / `Planned` / `Deprecated`. Source of truth is [`matrix.yml`](./matrix.yml).

--- a/selenium-webdriver/advanced/matrix.yml
+++ b/selenium-webdriver/advanced/matrix.yml
@@ -1,0 +1,95 @@
+# PER-8195 Phase 3 — Automate Selenium-JS matrix-row mapping.
+# Test code: tests/advanced.test.js (jest).
+#
+# Percy on Automate posts to /percy/automateScreenshot (BrowserStack-side
+# capture), not /percy/snapshot (DOM serialization). Some rows from the
+# regular web matrix don't apply.
+
+sdk: automate-selenium-javascript
+driver: selenium-webdriver
+package: '@percy/selenium-webdriver'
+language: javascript
+mode: automate
+sdk_min_version: '2.2.6'
+cli_min_version: '1.31.13'
+
+rows:
+  - id: ignore_region_xpaths
+    state: covered
+    test: 'exercises ignore_region_xpaths'
+  - id: ignore_region_selectors
+    state: covered
+    test: 'exercises ignore_region_selectors (CSS)'
+  - id: custom_ignore_regions
+    state: covered
+    test: 'exercises custom_ignore_regions'
+  - id: consider_region_xpaths
+    state: covered
+    test: 'exercises consider_region_xpaths'
+  - id: consider_region_selectors
+    state: covered
+    test: 'exercises consider_region_selectors (CSS)'
+  - id: freeze_animation
+    state: covered
+    test: 'exercises freeze_animation'
+  - id: percy_css
+    state: covered
+    test: 'exercises percy_css'
+  - id: sync
+    state: covered
+    test: 'exercises sync mode'
+  - id: test_case
+    state: covered
+    test: 'exercises test_case + labels metadata'
+  - id: labels
+    state: covered
+    test: 'exercises test_case + labels metadata'
+
+  - id: build_metadata_via_env
+    state: covered
+    test: 'capabilities driven by PERCY_PROJECT / PERCY_BUILD env'
+  - id: env_percy_branch
+    state: covered
+  - id: env_percy_commit
+    state: covered
+
+  # Not exposed in Percy on Automate flow (server-side capture).
+  - id: widths
+    state: n_a
+    reason: 'Percy on Automate captures from a browser already at the configured viewport; widths is set via driver.window().setRect.'
+  - id: min_height
+    state: n_a
+    reason: 'Server-side capture; min-height not applicable to /percy/automateScreenshot body.'
+  - id: enable_javascript
+    state: n_a
+    reason: 'JS already executes in the live browser session.'
+  - id: scope
+    state: n_a
+    reason: 'Not in /percy/automateScreenshot body.'
+  - id: discovery
+    state: n_a
+    reason: 'No asset discovery in Automate mode.'
+  - id: dom_transformation
+    state: n_a
+    reason: 'No DOM serialization in Automate mode.'
+  - id: responsive_snapshot_capture
+    state: n_a
+    reason: 'Server-side capture from a single viewport per session.'
+  - id: readiness_preset
+    state: n_a
+    reason: 'Readiness presets are for in-process DOM SDKs, not Automate.'
+  - id: device_pixel_ratio
+    state: n_a
+    reason: 'DPR fixed by the BrowserStack VM.'
+  - id: browsers
+    state: n_a
+    reason: 'Browser is the live driver browser; multi-browser comparison is parallel sessions.'
+  - id: regions
+    state: n_a
+    reason: 'Use ignore_region_xpaths / ignore_region_selectors / custom_ignore_regions instead.'
+
+  - id: percy_yml_global_config
+    state: covered
+  - id: environment_info_reporting
+    state: covered
+    test: 'automatic via @percy/selenium-webdriver client info'

--- a/selenium-webdriver/advanced/matrix.yml
+++ b/selenium-webdriver/advanced/matrix.yml
@@ -47,7 +47,7 @@ rows:
 
   - id: build_metadata_via_env
     state: covered
-    test: 'capabilities driven by PERCY_PROJECT / PERCY_BUILD env'
+    test: 'capabilities driven by BROWSERSTACK_PROJECT_NAME / BROWSERSTACK_BUILD_NAME env'
   - id: env_percy_branch
     state: covered
   - id: env_percy_commit

--- a/selenium-webdriver/advanced/package.json
+++ b/selenium-webdriver/advanced/package.json
@@ -8,11 +8,9 @@
   "dependencies": {
     "@percy/cli": "^1.31.13",
     "@percy/selenium-webdriver": "^2.2.6",
-    "dotenv": "^17.2.3",
     "selenium-webdriver": "^4.36.0"
   },
   "devDependencies": {
-    "@types/jest": "^30.0.0",
     "jest": "^30.2.0"
   }
 }

--- a/selenium-webdriver/advanced/package.json
+++ b/selenium-webdriver/advanced/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "example-percy-automate-selenium-js-advanced",
+  "private": true,
+  "description": "Advanced Percy on Automate + Selenium-WebDriver example. Exercises the full applicable Percy on Automate SDK feature surface against the BrowserStack hub.",
+  "scripts": {
+    "test:advanced": "npx jest tests/advanced.test.js"
+  },
+  "dependencies": {
+    "@percy/cli": "^1.31.13",
+    "@percy/selenium-webdriver": "^2.2.6",
+    "dotenv": "^17.2.3",
+    "selenium-webdriver": "^4.36.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^30.0.0",
+    "jest": "^30.2.0"
+  }
+}

--- a/selenium-webdriver/advanced/tests/advanced.test.js
+++ b/selenium-webdriver/advanced/tests/advanced.test.js
@@ -1,0 +1,98 @@
+// PER-8195 Phase 3 — automate-selenium-javascript advanced example.
+// Each test exercises one row of the Percy on Automate matrix. See
+// ../matrix.yml for the canonical mapping.
+//
+// Runs against the BrowserStack Automate hub. Requires
+// BROWSERSTACK_USERNAME, BROWSERSTACK_ACCESS_KEY, PERCY_TOKEN env vars.
+
+const { Builder, By } = require('selenium-webdriver')
+const { percyScreenshot } = require('@percy/selenium-webdriver')
+
+jest.setTimeout(600000)
+
+describe('Percy on Automate — Advanced', () => {
+  let driver
+
+  beforeAll(async () => {
+    const capabilities = {
+      'bstack:options': {
+        os: 'Windows',
+        osVersion: '11',
+        browserVersion: 'latest',
+        projectName: process.env.PERCY_PROJECT || 'Percy Automate Selenium-JS Advanced',
+        buildName: process.env.PERCY_BUILD || 'Advanced Selenium JS',
+        sessionName: 'advanced_visual_test',
+        userName: process.env.BROWSERSTACK_USERNAME,
+        accessKey: process.env.BROWSERSTACK_ACCESS_KEY,
+      },
+      browserName: 'Chrome',
+    }
+    driver = new Builder()
+      .usingServer('https://hub-cloud.browserstack.com/wd/hub')
+      .withCapabilities(capabilities)
+      .build()
+    await driver.manage().window().setRect({ width: 1280, height: 1024 })
+    await driver.get('https://bstackdemo.com/')
+  })
+
+  afterAll(async () => {
+    await driver.quit()
+  })
+
+  test('exercises baseline screenshot', async () => {
+    await percyScreenshot(driver, 'BStackDemo — baseline')
+  })
+
+  test('exercises ignore_region_xpaths', async () => {
+    await percyScreenshot(driver, 'BStackDemo — ignore via xpath', {
+      ignore_region_xpaths: ['//*[@id="signin"]'],
+    })
+  })
+
+  test('exercises ignore_region_selectors (CSS)', async () => {
+    await percyScreenshot(driver, 'BStackDemo — ignore via CSS selector', {
+      ignore_region_selectors: ['#signin', '.shelf-container-header'],
+    })
+  })
+
+  test('exercises custom_ignore_regions', async () => {
+    await percyScreenshot(driver, 'BStackDemo — custom ignore region', {
+      custom_ignore_regions: [{ top: 0, bottom: 100, left: 0, right: 1280 }],
+    })
+  })
+
+  test('exercises consider_region_xpaths', async () => {
+    await percyScreenshot(driver, 'BStackDemo — consider via xpath', {
+      consider_region_xpaths: ['//*[@id="__next"]'],
+    })
+  })
+
+  test('exercises consider_region_selectors (CSS)', async () => {
+    await percyScreenshot(driver, 'BStackDemo — consider via CSS selector', {
+      consider_region_selectors: ['#__next > div > div > main'],
+    })
+  })
+
+  test('exercises freeze_animation', async () => {
+    await percyScreenshot(driver, 'BStackDemo — freeze_animation', {
+      freeze_animation: true,
+    })
+  })
+
+  test('exercises percy_css', async () => {
+    await percyScreenshot(driver, 'BStackDemo — percy_css', {
+      percy_css: '.shelf-container { background: #fffde7 !important; }',
+    })
+  })
+
+  test('exercises sync mode', async () => {
+    await percyScreenshot(driver, 'BStackDemo — sync', { sync: true })
+  })
+
+  test('exercises test_case + labels metadata', async () => {
+    await percyScreenshot(driver, 'BStackDemo — test_case + labels', {
+      test_case: 'home-smoke',
+      labels: 'smoke,automate-selenium-js',
+    })
+  })
+})

--- a/selenium-webdriver/advanced/tests/advanced.test.js
+++ b/selenium-webdriver/advanced/tests/advanced.test.js
@@ -5,7 +5,7 @@
 // Runs against the BrowserStack Automate hub. Requires
 // BROWSERSTACK_USERNAME, BROWSERSTACK_ACCESS_KEY, PERCY_TOKEN env vars.
 
-const { Builder, By } = require('selenium-webdriver')
+const { Builder } = require('selenium-webdriver')
 const { percyScreenshot } = require('@percy/selenium-webdriver')
 
 jest.setTimeout(600000)
@@ -19,8 +19,8 @@ describe('Percy on Automate — Advanced', () => {
         os: 'Windows',
         osVersion: '11',
         browserVersion: 'latest',
-        projectName: process.env.PERCY_PROJECT || 'Percy Automate Selenium-JS Advanced',
-        buildName: process.env.PERCY_BUILD || 'Advanced Selenium JS',
+        projectName: process.env.BROWSERSTACK_PROJECT_NAME || 'Percy Automate Selenium-JS Advanced',
+        buildName: process.env.BROWSERSTACK_BUILD_NAME || 'Advanced Selenium JS',
         sessionName: 'advanced_visual_test',
         userName: process.env.BROWSERSTACK_USERNAME,
         accessKey: process.env.BROWSERSTACK_ACCESS_KEY,
@@ -86,7 +86,13 @@ describe('Percy on Automate — Advanced', () => {
   })
 
   test('exercises sync mode', async () => {
-    await percyScreenshot(driver, 'BStackDemo — sync', { sync: true })
+    // sync: true blocks until Percy finishes processing the snapshot and
+    // returns the comparison result (status, comparison URLs, diff data) so
+    // it can be consumed inline — this is what distinguishes it from a normal
+    // fire-and-forget percyScreenshot call.
+    const result = await percyScreenshot(driver, 'BStackDemo — sync', { sync: true })
+    console.log('Percy sync result:', JSON.stringify(result))
+    expect(result).toBeDefined()
   })
 
   test('exercises test_case + labels metadata', async () => {


### PR DESCRIPTION
## Summary
First Phase 3 PR for PER-8195. Adds `selenium-webdriver/advanced/` exercising the full applicable Percy on Automate feature surface for `@percy/selenium-webdriver` (Automate mode).

10 jest tests in `tests/advanced.test.js`:
- ignore regions (xpath / CSS selector / custom bbox)
- consider regions (xpath / CSS selector)
- `freeze_animation`
- `percy_css`
- sync mode
- test_case + labels metadata

DOM-only options (widths, min_height, enable_javascript, scope, discovery, dom_transformation, responsiveSnapshotCapture, readiness preset, devicePixelRatio, browsers) marked `N/A` in `matrix.yml` — Percy on Automate captures server-side from a live browser session, not via DOM serialization. The endpoint is `/percy/automateScreenshot`, not `/percy/snapshot`.

Issue: [PER-8195](https://browserstack.atlassian.net/browse/PER-8195). Parent: percy/percy-public-repos-parent (Phase 3 PR pending).

## CI shape
`workflow_dispatch`-only — Percy on Automate CI requires a real BrowserStack Automate session. Needs repo secrets `BROWSERSTACK_USERNAME` / `BROWSERSTACK_ACCESS_KEY` / `PERCY_TOKEN`.

The workflow accepts a `driver` input — currently only `selenium-webdriver` works; `webdriverio` is a planned follow-up.

## Test plan
- [ ] Maintainer triggers `Advanced — Percy on Automate` workflow manually with hub secrets set.
- [ ] Verify a Percy build lands with the 10 advanced screenshots on the BStackDemo page.
- [ ] Verify ignore/consider regions render as expected on the comparison view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PER-8195]: https://browserstack.atlassian.net/browse/PER-8195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ